### PR TITLE
Add future result utility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
   "crates/brace-util",
+  "crates/brace-util-future",
 ]

--- a/crates/brace-util-future/Cargo.toml
+++ b/crates/brace-util-future/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "brace-util-future"
+version = "0.1.0"
+authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
+description = "Future utilities for the brace framework."
+repository = "https://github.com/brace-rs/brace-util"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[dev-dependencies]
+tokio = { version = "0.2", features = ["rt-core", "macros"] }

--- a/crates/brace-util-future/src/lib.rs
+++ b/crates/brace-util-future/src/lib.rs
@@ -1,0 +1,3 @@
+pub use self::result::FutureResult;
+
+pub mod result;

--- a/crates/brace-util-future/src/result.rs
+++ b/crates/brace-util-future/src/result.rs
@@ -1,0 +1,91 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pub enum FutureResult<'a, T, E> {
+    Result(Box<Option<Result<T, E>>>),
+    Future(Pin<Box<dyn Future<Output = Result<T, E>> + 'a>>),
+}
+
+impl<'a, T, E> FutureResult<'a, T, E> {
+    pub fn from_ok(ok: T) -> Self {
+        Self::Result(Box::new(Some(Ok(ok))))
+    }
+
+    pub fn from_err(err: E) -> Self {
+        Self::Result(Box::new(Some(Err(err))))
+    }
+
+    pub fn from_result(result: Result<T, E>) -> Self {
+        Self::Result(Box::new(Some(result)))
+    }
+
+    pub fn from_future<F>(future: F) -> Self
+    where
+        F: Future<Output = Result<T, E>> + 'a,
+    {
+        Self::Future(Box::pin(future))
+    }
+}
+
+impl<'a, T, E> Future for FutureResult<'a, T, E> {
+    type Output = Result<T, E>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match *self.as_mut() {
+            Self::Result(ref mut result) => Poll::Ready(result.take().expect("use after resolve")),
+            Self::Future(ref mut future) => future.as_mut().poll(cx),
+        }
+    }
+}
+
+impl<'a, T, E> From<Result<T, E>> for FutureResult<'a, T, E> {
+    fn from(result: Result<T, E>) -> Self {
+        Self::from_result(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FutureResult;
+
+    #[derive(Debug, PartialEq)]
+    struct Error;
+
+    #[tokio::test]
+    async fn test_future_result_from_ok() {
+        let future = FutureResult::<String, Error>::from_ok(String::from("ok"));
+        let result = future.await;
+
+        assert_eq!(result, Ok(String::from("ok")));
+    }
+
+    #[tokio::test]
+    async fn test_future_result_from_err() {
+        let future = FutureResult::<String, Error>::from_err(Error);
+        let result = future.await;
+
+        assert_eq!(result, Err(Error));
+    }
+
+    #[tokio::test]
+    async fn test_future_result_from_result() {
+        let future = FutureResult::<&str, Error>::from(Ok("result"));
+        let result = future.await;
+
+        assert_eq!(result, Ok("result"));
+    }
+
+    #[tokio::test]
+    async fn test_future_result_from_future() {
+        let future = FutureResult::from_future(async {
+            FutureResult::from_future(async {
+                FutureResult::<&str, Error>::from(Ok("future")).await
+            })
+            .await
+        });
+        let result = future.await;
+
+        assert_eq!(result, Ok("future"));
+    }
+}

--- a/crates/brace-util/Cargo.toml
+++ b/crates/brace-util/Cargo.toml
@@ -6,3 +6,10 @@ description = "A set of common utilities for the brace framework."
 repository = "https://github.com/brace-rs/brace-util"
 license = "MIT OR Apache-2.0"
 edition = "2018"
+
+[features]
+default = ["future"]
+future = ["brace-util-future"]
+
+[dependencies]
+brace-util-future = { path = "../brace-util-future", optional = true }

--- a/crates/brace-util/src/lib.rs
+++ b/crates/brace-util/src/lib.rs
@@ -1,13 +1,2 @@
-pub fn add_two(a: i32) -> i32 {
-    a + 2
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_adds_two() {
-        assert_eq!(add_two(2), 4);
-    }
-}
+#[cfg(feature = "future")]
+pub use brace_util_future as future;


### PR DESCRIPTION
This adds a useful struct for handling future results that may or may not be ready. Previous versions of the `futures` crate included a struct with the same name which has since been more aptly named `Ready`.