### PR TITLE
Update continuous integration lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         args: --all -- --check
 
     - name: Clippy
-      uses: brace-rs/clippy-check@b75a09651cc90c3921c41888815fe6a7a0b0adae
+      uses: actions-rs/clippy-check@v1
       with:
         args: --all -- -D warnings
         name: Lint / Results


### PR DESCRIPTION
This updates the `clippy-check` task of the continuous integration workflow `lint` job to use the latest action now that a fix for unnamed workflows has been merged.