### PR TITLE
Add future result done as alias of unit type ok

### DIFF
--- a/crates/brace-util-future/src/result.rs
+++ b/crates/brace-util-future/src/result.rs
@@ -28,6 +28,12 @@ impl<'a, T, E> FutureResult<'a, T, E> {
     }
 }
 
+impl<'a, E> FutureResult<'a, (), E> {
+    pub fn done() -> Self {
+        Self::ok(())
+    }
+}
+
 impl<'a, T, E> Future for FutureResult<'a, T, E> {
     type Output = Result<T, E>;
 
@@ -85,5 +91,13 @@ mod tests {
         let result = future.await;
 
         assert_eq!(result, Ok("future"));
+    }
+
+    #[tokio::test]
+    async fn test_done() {
+        let future = FutureResult::<(), Error>::done();
+        let result = future.await;
+
+        assert_eq!(result, Ok(()));
     }
 }


### PR DESCRIPTION
This adds the `done` method for future results that simply acts as an alias of `ok(())`.